### PR TITLE
Bugfix for py3 support, clean up module imports

### DIFF
--- a/porder/async_downloader.py
+++ b/porder/async_downloader.py
@@ -9,7 +9,6 @@ from retrying import retry
 from pySmartDL import SmartDL
 from planet.api.utils import read_planet_json
 from planet.api.auth import find_api_key
-os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
 #Get Planet API and Authenticate SESSION
 try:

--- a/porder/diffcheck.py
+++ b/porder/diffcheck.py
@@ -7,8 +7,6 @@ import os
 import glob
 import sys
 from planet.api.auth import find_api_key
-os.chdir(os.path.dirname(os.path.realpath(__file__)))
-pathway = os.path.dirname(os.path.realpath(__file__))
 
 # Get API key and authenticate session
 try:

--- a/porder/downloader.py
+++ b/porder/downloader.py
@@ -7,7 +7,6 @@ import sys
 import csv
 from planet.api.utils import read_planet_json
 from planet.api.auth import find_api_key
-os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
 #Get Planet API and Authenticate SESSION
 try:

--- a/porder/geojson2id.py
+++ b/porder/geojson2id.py
@@ -9,8 +9,6 @@ import sys
 from shapely.geometry import shape
 from planet.api.utils import read_planet_json
 from planet.api.auth import find_api_key
-os.chdir(os.path.dirname(os.path.realpath(__file__)))
-pathway=os.path.dirname(os.path.realpath(__file__))
 
 #Create an empty geojson template
 temp={"coordinates":[],"type":"Polygon"}

--- a/porder/multiproc_pydl.py
+++ b/porder/multiproc_pydl.py
@@ -11,7 +11,7 @@ import sys
 from retrying import retry
 from planet.api.utils import read_planet_json
 from planet.api.auth import find_api_key
-os.chdir(os.path.dirname(os.path.realpath(__file__)))
+
 #Get Planet API and Authenticate SESSION
 try:
     PL_API_KEY = find_api_key()

--- a/porder/order_now.py
+++ b/porder/order_now.py
@@ -22,23 +22,7 @@ except:
 url = 'https://api.planet.com/compute/ops/orders/v2'
 
 def order(**kwargs):
-    for key,value in kwargs.iteritems():
-        if key=='op':
-            for items in value:
-                if items=='clip':
-                    dbundle['tools'].append(dclip)
-                elif items=='toar':
-                    dbundle['tools'].append(dtoar)
-                elif items=='zip':
-                    dbundle.update(dzip)
-                elif items=='email':
-                    dbundle.update(demail)
-                elif items=='composite':
-                    dbundle['tools'].append(dcomposite)
-                elif items=='reproject':
-                    dbundle['tools'].append(dreproject)
-                elif items=='compression':
-                    dbundle['tools'].append(dtiff)
+    for key,value in kwargs.items():
         if key=='name':
             dbundle['name']=value
         if key=='item':
@@ -61,7 +45,23 @@ def order(**kwargs):
                         l.append(item_id)
             dbundle['products'][0]['item_ids'] = l
     k=dbundle
-    for key,value in kwargs.iteritems():
+    for key,value in kwargs.items():
+        if key=='op' and value!=None:
+            for items in value:
+                if items=='clip':
+                    dbundle['tools'].append(dclip)
+                elif items=='toar':
+                    dbundle['tools'].append(dtoar)
+                elif items=='zip':
+                    dbundle.update(dzip)
+                elif items=='email':
+                    dbundle.update(demail)
+                elif items=='composite':
+                    dbundle['tools'].append(dcomposite)
+                elif items=='reproject':
+                    dbundle['tools'].append(dreproject)
+                elif items=='compression':
+                    dbundle['tools'].append(dtiff)
         if key=='boundary' and value!=None:
                 for items in k['tools']:
                     if items.get('clip'):

--- a/porder/porder.py
+++ b/porder/porder.py
@@ -2,15 +2,12 @@ import subprocess
 import os
 import sys
 import argparse
-from geojson2id import idl
-from text_split import idsplit
-from order_now import order
-from downloader import download
-from diffcheck import checker
-from async_downloader import asyncdownload
-os.chdir(os.path.dirname(os.path.realpath(__file__)))
-lpath=os.path.dirname(os.path.realpath(__file__))
-sys.path.append(lpath)
+from porder.geojson2id import idl
+from porder.text_split import idsplit
+from porder.order_now import order
+from porder.downloader import download
+from porder.diffcheck import checker
+from porder.async_downloader import asyncdownload
 
 #Get quota for your account
 def planet_quota():


### PR DESCRIPTION
- The chdir calls were creating issues when using a relative path for the idlist filename (e.g., './ids.txt')
- Fixed dictionary iteration for Python 2/3 compatibility
- Move the 'op' key handling to the optional argument parsing within order_now.order() and check for value of None